### PR TITLE
Add mobile drawer, hero module, and site functionality plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,96 +1,92 @@
 # WordPress Boilerplate Theme
 
-A lean, modern WordPress starter theme with **Tailwind CSS v4**, **esbuild**, and optional modules (Alpine.js, Fancybox, Swiper).
+A lean WordPress starter that pairs **Tailwind CSS v4**, **esbuild**, and clean PHP templates. It ships with a sticky header, mobile drawer navigation, and a modular hero layout you can toggle per project.
 
 ---
 
 ## 🚀 Quick Start
 
-1. Clone this theme into your WordPress `wp-content/themes/` directory.
+1. Copy or clone the theme into your WordPress installation under `wp-content/themes/`.
 2. Install dependencies:
    ```bash
    npm install
    ```
-3. Install dependencies:
+3. Start local builds while you work:
+   ```bash
    npm run watch
-4. Or build for production (minified):
+   ```
+   or compile a production build when you deploy:
+   ```bash
    npm run build
-5. Activate the theme in the WordPress admin, and you’re good to go.
+   ```
+4. Activate **WordPress Boilerplate 2025** in the WordPress admin.
 
-📦 Scripts
-npm install – install dependencies
+## 🧰 Build Commands
 
-npm run watch – watch and rebuild CSS/JS on changes
+| Command | Description |
+| ------- | ----------- |
+| `npm run watch` | Watches Tailwind (`src/css/tailwind.css`) and JavaScript (`src/js/main.js`) and rebuilds to `assets/css/main.css` and `assets/js/main.js`. |
+| `npm run build` | Runs one-off production builds for CSS and JS (minified, cache-friendly). |
 
-npm run build – one-time build (minified)
+## 🧭 Boilerplate Guide
 
-🗂 File Structure
-theme/
-├── style.css # Theme header + optional overrides
-├── functions.php # Boots theme, defines modules, pulls in inc/\*
-├── inc/
-│ ├── setup.php # Theme supports, menus, image sizes
-│ └── enqueue.php # Enqueues CSS/JS + optional modules
-├── assets/
-│ ├── css/main.css # Compiled Tailwind output
-│ └── js/main.js # Bundled JS output
-├── src/
-│ ├── css/tailwind.css # Tailwind entrypoint (@import "tailwindcss";)
-│ └── js/main.js # Theme JS entrypoint
-├── header.php # Calls wp_head()
-├── footer.php # Calls wp_footer()
-├── index.php # Default loop template
-└── front-page.php # Homepage template (optional)
-
-⚙️ Modules
-Modules are toggled in functions.php via $BP_MODULES:
-$BP_MODULES = array(
-'alpine' => false, // Alpine.js
-'fancybox' => false, // Fancybox (lightbox)
-'swiper' => false, // Swiper (sliders)
+### Optional modules
+Module toggles live in `functions.php` inside `$GLOBALS['BP_MODULES']`. Flip a module to `true` per project (or filter the array) to enqueue CDN assets:
+```php
+$GLOBALS['BP_MODULES'] = array(
+    'alpine'   => false,
+    'fancybox' => false,
+    'swiper'   => false,
 );
-Set to true to enqueue the CDN assets.
+```
 
-🎨 Styling
+### Mobile drawer navigation
+The sticky header renders a desktop menu plus the mobile toggle button (`#mobile-nav-toggle`) with open (`#icon-open`) and close (`#icon-close`) icons. The drawer itself lives in `template-parts/navigation-mobile.php` and is included directly after the header via `get_template_part('template-parts/navigation-mobile');`.
 
-Tailwind v4 is installed and configured.
+The hidden `<span>` inside `header.php` safelists the utility classes that the JavaScript toggles (`translate-x-*`, `opacity-*`, `pointer-events-*`, `overflow-hidden`). Keep that span (or add an equivalent) if you adjust the header so Tailwind does not purge those classes.
 
-Add global base styles, components, and utilities inside src/css/tailwind.css.
+### Hero section module
+A static hero scaffold is stored at `template-parts/hero/hero.php`. It is already referenced in `front-page.php`:
+```php
+get_template_part( 'template-parts/hero/hero' );
+```
+Swap the placeholder copy, wire it up to ACF, or add a slider script when you need it—no additional enqueueing is enabled by default.
 
-Run npm run build or npm run watch to recompile into assets/css/main.css.
+### Site Functionality plugin
+Project-specific logic (custom post types, taxonomies, ACF field groups) belongs in `wp-content/plugins/site-functionality/site-functionality.php`. The scaffold ships with commented examples so you can quickly uncomment or adapt them for each client site. Activate this plugin alongside the theme to keep presentation and functionality separate.
 
-✅ Requirements
+## 🗂 File Structure
 
-Node.js 18+
+```
+theme/
+├── style.css                      # Theme header
+├── functions.php                  # Boots the theme + module toggles
+├── inc/
+│   ├── setup.php                  # Theme supports and menus
+│   └── enqueue.php                # Enqueues CSS/JS + optional modules
+├── assets/
+│   ├── css/main.css               # Compiled Tailwind output (generated)
+│   └── js/main.js                 # Bundled JS output (generated)
+├── src/
+│   ├── css/tailwind.css           # Tailwind entrypoint
+│   └── js/
+│       ├── main.js                # Theme JS entrypoint (imports drawer)
+│       └── mobile-drawer.js       # Off-canvas navigation logic
+├── template-parts/
+│   ├── hero/hero.php              # Hero module scaffold
+│   └── navigation-mobile.php      # Mobile drawer markup
+├── front-page.php                 # Example home template including hero
+├── header.php / footer.php        # Layout chrome
+└── wp-content/plugins/
+    └── site-functionality/        # Project functionality plugin scaffold
+```
 
-WordPress 6.0+
+## 🎨 Styling
 
-PHP 7.4+
+Tailwind CSS v4 drives all styling. Edit `src/css/tailwind.css` to add global layers or utilities, then rebuild with `npm run watch` or `npm run build`.
 
-🆕 Creating a New Project
+## ✅ Requirements
 
-When starting a new site:
-
-1. Copy the boilerplate into wp-content/themes/your-theme-name.
-2. Update style.css header:
-
-Update style.css header:
-/_
-Theme Name: My Project Theme
-Author: Your Name
-Description: Custom theme for [Project Name].
-Version: 1.0.0
-Text Domain: my-project
-_/ 4. Edit functions.php → flip module toggles (alpine, fancybox, swiper) depending on what you need. 4. Install dependencies:
-npm install 5. Run the build:
-npm run watch
-
-6. Customize templates: duplicate/extend index.php into page.php, single.php, archive.php as needed.
-   7.Start coding 🚀
-
-📝 Notes
-This boilerplate is intentionally minimal: no Customizer, no widgets, no legacy clutter.
-
-Extend templates (page.php, single.php, archive.php, etc.) as needed per project.
-
-Compatible with child themes or direct extension.
+- Node.js 18+
+- WordPress 6.0+
+- PHP 7.4+

--- a/front-page.php
+++ b/front-page.php
@@ -1,5 +1,15 @@
-<?php get_header(); ?>
-<main id="main" class="site-main container section" role="main">
-    <!-- template content -->
+<?php
+get_header();
+get_template_part( 'template-parts/hero/hero' );
+?>
+<main id="main" class="site-main mx-auto w-full max-w-4xl px-4 py-16" role="main">
+    <?php
+    while ( have_posts() ) :
+        the_post();
+        the_content();
+    endwhile;
+    ?>
 </main>
-<?php get_footer(); ?>
+<?php
+get_footer();
+?>

--- a/functions.php
+++ b/functions.php
@@ -2,56 +2,95 @@
 /**
  * Theme bootstrap
  *
- * @package WordPress_Boilerplate
+ * @package WordPress_Boilerplate_2025
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-/**
- * Version (used for cache keys elsewhere if needed).
- * Keep in sync with style.css header if you wish.
- */
-define( 'BP_THEME_VERSION', '0.1.0' );
+if ( ! defined( 'BP_THEME_VERSION' ) ) {
+    define( 'BP_THEME_VERSION', '0.1.0' );
+}
 
-/**
- * Core includes
- */
-require_once __DIR__ . '/inc/setup.php';
-require_once __DIR__ . '/inc/enqueue.php';
+require_once get_template_directory() . '/inc/setup.php';
+require_once get_template_directory() . '/inc/enqueue.php';
 
-/**
- * Optional feature modules
- * Flip to true per project, or override via the 'bp/modules' filter.
- *
- * Available modules (handled in inc/enqueue.php):
- * - alpine    : Loads Alpine.js (CDN)
- * - fancybox  : Loads Fancybox (CSS/JS via CDN)
- * - swiper    : Loads Swiper (CSS/JS via CDN)
- */
-$BP_MODULES = array(
+if ( ! function_exists( 'bp_get_part' ) ) {
+    /**
+     * Wrapper for get_template_part with optional arguments.
+     *
+     * @param string     $slug Template slug.
+     * @param string|null $name Optional. Template name.
+     * @param array      $args Optional. Arguments passed to the template.
+     */
+    function bp_get_part( $slug, $name = null, $args = array() ) {
+        if ( empty( $slug ) ) {
+            return;
+        }
+
+        get_template_part( $slug, $name, $args );
+    }
+}
+
+if ( ! function_exists( 'bp_fallback_menu' ) ) {
+    /**
+     * Fallback menu that lists top-level pages when no menu is assigned.
+     *
+     * @param array|object $args Arguments supplied by wp_nav_menu().
+     * @return string|null Rendered markup when echo is false.
+     */
+    function bp_fallback_menu( $args ) {
+        $args = (array) $args;
+
+        $defaults = array(
+            'container'   => '',
+            'menu_id'     => '',
+            'menu_class'  => '',
+            'depth'       => 1,
+            'link_before' => '',
+            'link_after'  => '',
+            'echo'        => true,
+        );
+
+        $args = wp_parse_args( $args, $defaults );
+
+        $pages = wp_list_pages(
+            array(
+                'depth'      => (int) $args['depth'],
+                'echo'       => false,
+                'title_li'   => '',
+                'sort_column'=> 'menu_order,post_title',
+            )
+        );
+
+        if ( empty( $pages ) ) {
+            return null;
+        }
+
+        $menu_id    = $args['menu_id'] ? ' id="' . esc_attr( $args['menu_id'] ) . '"' : '';
+        $menu_class = $args['menu_class'] ? ' class="' . esc_attr( $args['menu_class'] ) . '"' : '';
+
+        $output = '<ul' . $menu_id . $menu_class . '>' . $pages . '</ul>';
+
+        if ( $args['echo'] ) {
+            echo $output; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+            return null;
+        }
+
+        return $output;
+    }
+}
+
+$bp_modules = array(
     'alpine'   => false,
     'fancybox' => false,
     'swiper'   => false,
 );
 
 /**
- * Allow child themes / plugins to override module toggles.
- * Example:
- *   add_filter('bp/modules', fn($m) => array_merge($m, ['alpine' => true]));
+ * Allow plugins or child themes to filter module toggles.
  */
-$BP_MODULES = apply_filters( 'bp/modules', $BP_MODULES );
+$bp_modules = apply_filters( 'bp/modules', $bp_modules );
 
-/**
- * (Optional) expose toggles globally for enqueue.php
- */
-$GLOBALS['BP_MODULES'] = $BP_MODULES;
-
-/**
- * Housekeeping: add a small body class to help target this theme if needed.
- */
-add_filter( 'body_class', function( $classes ) {
-    $classes[] = 'bp-theme';
-    return $classes;
-});
+$GLOBALS['BP_MODULES'] = $bp_modules;

--- a/header.php
+++ b/header.php
@@ -1,17 +1,65 @@
 <!doctype html>
 <html <?php language_attributes(); ?>>
-
 <head>
-    <meta charset="<?php bloginfo('charset'); ?>">
+    <meta charset="<?php bloginfo( 'charset' ); ?>">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <?php wp_head(); ?>
 </head>
 
 <body <?php body_class(); ?>>
-    <?php wp_body_open(); ?>
+<?php wp_body_open(); ?>
 
-    <header class="site-header container py-6">
-        <a class="text-2xl font-semibold no-underline hover:underline" href="<?php echo esc_url( home_url('/') ); ?>">
-            <?php bloginfo('name'); ?>
-        </a>
-    </header>
+<header class="sticky top-0 z-50 border-b border-slate-200 bg-white/95 py-4 shadow-sm backdrop-blur">
+    <div class="mx-auto flex w-full max-w-6xl items-center justify-between gap-6 px-4 lg:px-8">
+        <div class="flex items-center gap-3">
+            <?php if ( has_custom_logo() ) : ?>
+                <div class="shrink-0">
+                    <?php the_custom_logo(); ?>
+                </div>
+            <?php else : ?>
+                <a class="text-xl font-semibold text-slate-900 no-underline transition hover:text-slate-600" href="<?php echo esc_url( home_url( '/' ) ); ?>">
+                    <?php bloginfo( 'name' ); ?>
+                </a>
+            <?php endif; ?>
+        </div>
+
+        <nav class="hidden items-center gap-8 text-sm font-medium text-slate-900 lg:flex" aria-label="<?php esc_attr_e( 'Primary Menu', 'boilerplate' ); ?>">
+            <?php
+            wp_nav_menu(
+                array(
+                    'theme_location' => 'primary',
+                    'menu_class'     => 'flex items-center gap-8',
+                    'container'      => '',
+                    'fallback_cb'    => 'bp_fallback_menu',
+                    'depth'          => 1,
+                )
+            );
+            ?>
+        </nav>
+
+        <div class="flex items-center gap-3 lg:hidden">
+            <button
+                id="mobile-nav-toggle"
+                type="button"
+                class="inline-flex items-center justify-center rounded-full border border-slate-200 p-2 text-slate-700 transition hover:border-slate-300 hover:text-slate-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 focus-visible:ring-offset-2"
+                aria-controls="mobile-nav"
+                aria-expanded="false"
+            >
+                <span class="sr-only"><?php esc_html_e( 'Toggle navigation', 'boilerplate' ); ?></span>
+                <span id="icon-open" aria-hidden="true">
+                    <svg class="h-6 w-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" viewBox="0 0 24 24">
+                        <path d="M4 7h16M4 12h16M4 17h16" />
+                    </svg>
+                </span>
+                <span id="icon-close" class="hidden" aria-hidden="true">
+                    <svg class="h-6 w-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" viewBox="0 0 24 24">
+                        <path d="M6 6l12 12M18 6l-12 12" />
+                    </svg>
+                </span>
+            </button>
+        </div>
+    </div>
+    <span class="sr-only hidden -translate-x-4 translate-x-0 translate-x-full opacity-0 opacity-100 pointer-events-none pointer-events-auto overflow-hidden"></span>
+</header>
+
+<?php get_template_part( 'template-parts/navigation-mobile' ); ?>

--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -1,101 +1,102 @@
 <?php
 /**
- * Enqueue theme styles and scripts
+ * Enqueue theme styles, scripts, and optional modules.
  *
- * @package WordPress_Boilerplate
+ * @package WordPress_Boilerplate_2025
  */
 
-// Exit if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-/**
- * Enqueue styles and scripts.
- */
-function boilerplate_enqueue_assets() {
-    $theme_dir = get_template_directory();
-    $theme_uri = get_template_directory_uri();
+if ( ! function_exists( 'bp_enqueue_theme_assets' ) ) {
+    /**
+     * Load the compiled CSS and JS bundles with cache busting.
+     */
+    function bp_enqueue_theme_assets() {
+        $theme_dir = get_template_directory();
+        $theme_uri = get_template_directory_uri();
 
-    // CSS (compiled Tailwind build).
-    $css_rel = '/assets/css/main.css';
-    if ( file_exists( $theme_dir . $css_rel ) ) {
-        wp_enqueue_style(
-            'boilerplate-main-style',
-            $theme_uri . $css_rel,
-            array(),
-            filemtime( $theme_dir . $css_rel )
-        );
-    }
+        $css_rel  = '/assets/css/main.css';
+        $css_path = $theme_dir . $css_rel;
+        if ( file_exists( $css_path ) ) {
+            wp_enqueue_style(
+                'bp-main',
+                $theme_uri . $css_rel,
+                array(),
+                filemtime( $css_path )
+            );
+        }
 
-    // JS (compiled bundle).
-    $js_rel = '/assets/js/main.js';
-    if ( file_exists( $theme_dir . $js_rel ) ) {
-        wp_enqueue_script(
-            'boilerplate-main-js',
-            $theme_uri . $js_rel,
-            array(),
-            filemtime( $theme_dir . $js_rel ),
-            true // load in footer
-        );
-    }
-}
-add_action( 'wp_enqueue_scripts', 'boilerplate_enqueue_assets' );
-
-/**
- * Optional: enqueue module scripts if toggled in functions.php
- * Example: $BP_MODULES['alpine'] = true;
- */
-function boilerplate_enqueue_modules() {
-    global $BP_MODULES;
-
-    if ( ! is_array( $BP_MODULES ) ) {
-        return;
-    }
-
-    // Alpine.js
-    if ( ! empty( $BP_MODULES['alpine'] ) ) {
-        wp_enqueue_script(
-            'alpine-js',
-            'https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js',
-            array(),
-            null,
-            true
-        );
-    }
-
-    // Fancybox
-    if ( ! empty( $BP_MODULES['fancybox'] ) ) {
-        wp_enqueue_style(
-            'fancybox-css',
-            'https://cdn.jsdelivr.net/npm/@fancyapps/ui@5.0/dist/fancybox/fancybox.css',
-            array(),
-            '5.0'
-        );
-        wp_enqueue_script(
-            'fancybox-js',
-            'https://cdn.jsdelivr.net/npm/@fancyapps/ui@5.0/dist/fancybox/fancybox.umd.js',
-            array(),
-            '5.0',
-            true
-        );
-    }
-
-    // Swiper
-    if ( ! empty( $BP_MODULES['swiper'] ) ) {
-        wp_enqueue_style(
-            'swiper-css',
-            'https://cdn.jsdelivr.net/npm/swiper@10/swiper-bundle.min.css',
-            array(),
-            '10.0.0'
-        );
-        wp_enqueue_script(
-            'swiper-js',
-            'https://cdn.jsdelivr.net/npm/swiper@10/swiper-bundle.min.js',
-            array(),
-            '10.0.0',
-            true
-        );
+        $js_rel  = '/assets/js/main.js';
+        $js_path = $theme_dir . $js_rel;
+        if ( file_exists( $js_path ) ) {
+            wp_enqueue_script(
+                'bp-main',
+                $theme_uri . $js_rel,
+                array(),
+                filemtime( $js_path ),
+                true
+            );
+        }
     }
 }
-add_action( 'wp_enqueue_scripts', 'boilerplate_enqueue_modules', 20 );
+add_action( 'wp_enqueue_scripts', 'bp_enqueue_theme_assets' );
+
+if ( ! function_exists( 'bp_enqueue_optional_modules' ) ) {
+    /**
+     * Conditionally load optional front-end modules via CDN.
+     */
+    function bp_enqueue_optional_modules() {
+        $modules = array();
+
+        if ( isset( $GLOBALS['BP_MODULES'] ) && is_array( $GLOBALS['BP_MODULES'] ) ) {
+            $modules = $GLOBALS['BP_MODULES'];
+        }
+
+        if ( ! empty( $modules['alpine'] ) ) {
+            wp_enqueue_script(
+                'alpinejs',
+                'https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js',
+                array(),
+                null,
+                true
+            );
+        }
+
+        if ( ! empty( $modules['fancybox'] ) ) {
+            wp_enqueue_style(
+                'fancybox',
+                'https://cdn.jsdelivr.net/npm/@fancyapps/ui@5.0/dist/fancybox/fancybox.css',
+                array(),
+                '5.0'
+            );
+
+            wp_enqueue_script(
+                'fancybox',
+                'https://cdn.jsdelivr.net/npm/@fancyapps/ui@5.0/dist/fancybox/fancybox.umd.js',
+                array(),
+                '5.0',
+                true
+            );
+        }
+
+        if ( ! empty( $modules['swiper'] ) ) {
+            wp_enqueue_style(
+                'swiper',
+                'https://cdn.jsdelivr.net/npm/swiper@10/swiper-bundle.min.css',
+                array(),
+                '10.0.0'
+            );
+
+            wp_enqueue_script(
+                'swiper',
+                'https://cdn.jsdelivr.net/npm/swiper@10/swiper-bundle.min.js',
+                array(),
+                '10.0.0',
+                true
+            );
+        }
+    }
+}
+add_action( 'wp_enqueue_scripts', 'bp_enqueue_optional_modules', 20 );

--- a/inc/setup.php
+++ b/inc/setup.php
@@ -1,62 +1,62 @@
 <?php
 /**
- * Theme Setup
+ * Theme setup callbacks.
  *
- * Handles theme supports, menus, image sizes, and text domain.
- *
- * @package WordPress_Boilerplate
+ * @package WordPress_Boilerplate_2025
  */
 
-// Exit if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-/**
- * Theme setup callback.
- */
-function boilerplate_setup() {
-    // Make theme available for translation.
-    load_theme_textdomain( 'boilerplate', get_template_directory() . '/languages' );
+if ( ! function_exists( 'bp_theme_setup' ) ) {
+    /**
+     * Register theme supports and menus.
+     */
+    function bp_theme_setup() {
+        register_nav_menus(
+            array(
+                'primary' => __( 'Primary Menu', 'boilerplate' ),
+            )
+        );
 
-    // Add default posts and comments RSS feed links to head.
-    add_theme_support( 'automatic-feed-links' );
-
-    // Let WordPress manage the document title.
-    add_theme_support( 'title-tag' );
-
-    // Enable featured images.
-    add_theme_support( 'post-thumbnails' );
-
-    // Register navigation menus.
-    register_nav_menus( array(
-        'primary' => __( 'Primary Menu', 'boilerplate' ),
-    ) );
-
-    // Switch default core markup to valid HTML5.
-    add_theme_support( 'html5', array(
-        'search-form',
-        'comment-form',
-        'comment-list',
-        'gallery',
-        'caption',
-        'style',
-        'script',
-    ) );
-
-    // Support custom logo.
-    add_theme_support( 'custom-logo', array(
-        'height'      => 200,
-        'width'       => 200,
-        'flex-width'  => true,
-        'flex-height' => true,
-    ) );
-
-    // Add responsive embeds.
-    add_theme_support( 'responsive-embeds' );
-
-    // Example image sizes (adjust or remove if not needed).
-    add_image_size( 'card-thumb', 600, 400, true );
-    add_image_size( 'hero', 1600, 900, true );
+        add_theme_support( 'title-tag' );
+        add_theme_support( 'post-thumbnails' );
+        add_theme_support(
+            'html5',
+            array(
+                'comment-form',
+                'comment-list',
+                'gallery',
+                'caption',
+                'search-form',
+                'script',
+                'style',
+            )
+        );
+        add_theme_support(
+            'custom-logo',
+            array(
+                'height'      => 120,
+                'width'       => 400,
+                'flex-height' => true,
+                'flex-width'  => true,
+            )
+        );
+    }
 }
-add_action( 'after_setup_theme', 'boilerplate_setup' );
+add_action( 'after_setup_theme', 'bp_theme_setup' );
+
+if ( ! function_exists( 'bp_theme_body_class' ) ) {
+    /**
+     * Append a helper body class for the boilerplate.
+     *
+     * @param array $classes Body classes.
+     * @return array
+     */
+    function bp_theme_body_class( $classes ) {
+        $classes[] = 'bp-theme';
+        return $classes;
+    }
+}
+add_filter( 'body_class', 'bp_theme_body_class' );

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,0 +1,5 @@
+import { initMobileNavDrawer } from './mobile-drawer.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  initMobileNavDrawer();
+});

--- a/src/js/mobile-drawer.js
+++ b/src/js/mobile-drawer.js
@@ -1,0 +1,115 @@
+const TRANSITION_DURATION = 300;
+
+const prepareMenuItems = (nav) => {
+  const items = Array.from(nav.querySelectorAll('.mobile-stagger, .menu-item'));
+
+  items.forEach((item) => {
+    item.classList.add('mobile-stagger', 'opacity-0', '-translate-x-4', 'transition-all', 'duration-300');
+    item.classList.remove('opacity-100', 'translate-x-0');
+    item.style.transitionDelay = '';
+  });
+
+  return items;
+};
+
+const toggleIcons = (openIcon, closeIcon, isOpen) => {
+  if (!openIcon || !closeIcon) {
+    return;
+  }
+
+  openIcon.classList.toggle('hidden', isOpen);
+  closeIcon.classList.toggle('hidden', !isOpen);
+};
+
+const applyStagger = (items, isOpen) => {
+  items.forEach((item, index) => {
+    item.style.transitionDelay = isOpen ? `${index * 60}ms` : '';
+    item.classList.toggle('opacity-0', !isOpen);
+    item.classList.toggle('opacity-100', isOpen);
+    item.classList.toggle('-translate-x-4', !isOpen);
+    item.classList.toggle('translate-x-0', isOpen);
+  });
+};
+
+const lockBodyScroll = (isOpen) => {
+  document.body.classList.toggle('overflow-hidden', isOpen);
+};
+
+export const initMobileNavDrawer = () => {
+  const toggle = document.getElementById('mobile-nav-toggle');
+  const nav = document.getElementById('mobile-nav');
+  const backdrop = document.getElementById('mobile-backdrop');
+
+  if (!toggle || !nav || !backdrop) {
+    return;
+  }
+
+  const openIcon = document.getElementById('icon-open');
+  const closeIcon = document.getElementById('icon-close');
+  const menuItems = prepareMenuItems(nav);
+
+  let isOpen = false;
+  let closeTimeout = null;
+
+  const setState = (open) => {
+    if (isOpen === open) {
+      return;
+    }
+
+    isOpen = open;
+    toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+    nav.setAttribute('aria-hidden', open ? 'false' : 'true');
+
+    if (open) {
+      backdrop.hidden = false;
+    }
+
+    nav.classList.toggle('translate-x-full', !open);
+    nav.classList.toggle('translate-x-0', open);
+    nav.classList.toggle('opacity-0', !open);
+    nav.classList.toggle('opacity-100', open);
+    nav.classList.toggle('pointer-events-none', !open);
+    nav.classList.toggle('pointer-events-auto', open);
+
+    backdrop.classList.toggle('opacity-0', !open);
+    backdrop.classList.toggle('opacity-100', open);
+    backdrop.classList.toggle('pointer-events-none', !open);
+    backdrop.classList.toggle('pointer-events-auto', open);
+
+    applyStagger(menuItems, open);
+    toggleIcons(openIcon, closeIcon, open);
+    lockBodyScroll(open);
+
+    if (!open) {
+      if (closeTimeout) {
+        window.clearTimeout(closeTimeout);
+      }
+
+      closeTimeout = window.setTimeout(() => {
+        backdrop.hidden = true;
+        closeTimeout = null;
+      }, TRANSITION_DURATION);
+    }
+  };
+
+  toggle.addEventListener('click', () => {
+    setState(!isOpen);
+  });
+
+  backdrop.addEventListener('click', () => {
+    setState(false);
+  });
+
+  nav.addEventListener('click', (event) => {
+    const link = event.target instanceof HTMLElement ? event.target.closest('a') : null;
+    if (link) {
+      setState(false);
+    }
+  });
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && isOpen) {
+      setState(false);
+    }
+  });
+};

--- a/style.css
+++ b/style.css
@@ -1,0 +1,12 @@
+/*
+Theme Name: WordPress Boilerplate 2025
+Theme URI: https://example.com/
+Author: Your Name
+Author URI: https://example.com/
+Description: A clean starter boilerplate theme with Tailwind and ESBuild.
+Version: 0.1.0
+License: GNU General Public License v2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+Text Domain: boilerplate
+Tags: boilerplate, tailwind, minimal
+*/

--- a/template-parts/hero/hero.php
+++ b/template-parts/hero/hero.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Static hero module placeholder.
+ *
+ * @package WordPress_Boilerplate_2025
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+?>
+<section id="hero-slider-section" class="relative flex min-h-screen items-center overflow-hidden bg-slate-950 text-white">
+    <div id="hero-slide-wrapper" class="absolute inset-0 -z-10">
+        <div class="hero-slide absolute inset-0 h-full w-full bg-gradient-to-br from-slate-950 via-slate-900 to-slate-800">
+            <div class="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.08),_transparent_60%)]"></div>
+        </div>
+    </div>
+
+    <div class="relative z-10 w-full">
+        <div class="mx-auto flex w-full max-w-6xl flex-col gap-16 px-4 py-24 lg:flex-row lg:items-center lg:gap-24 lg:px-8">
+            <div class="max-w-xl space-y-6">
+                <span class="inline-flex items-center rounded-full bg-white/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-white/70">
+                    <?php esc_html_e( 'Hero Module', 'boilerplate' ); ?>
+                </span>
+                <h1 class="text-4xl font-bold leading-tight tracking-tight text-white sm:text-5xl lg:text-6xl">
+                    <?php esc_html_e( 'Launch faster with a dependable WordPress foundation.', 'boilerplate' ); ?>
+                </h1>
+                <p class="text-lg text-white/80">
+                    <?php esc_html_e( 'WordPress Boilerplate 2025 pairs Tailwind CSS with modern tooling so you can focus on custom design and content.', 'boilerplate' ); ?>
+                </p>
+                <div class="flex flex-wrap items-center gap-4">
+                    <a href="<?php echo esc_url( home_url( '/contact' ) ); ?>" class="inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-base font-semibold text-slate-900 transition hover:bg-slate-100">
+                        <?php esc_html_e( 'Start a Project', 'boilerplate' ); ?>
+                    </a>
+                    <a href="<?php echo esc_url( home_url( '/work' ) ); ?>" class="inline-flex items-center justify-center rounded-full border border-white/40 px-6 py-3 text-base font-semibold text-white transition hover:border-white hover:bg-white/10">
+                        <?php esc_html_e( 'View Latest Work', 'boilerplate' ); ?>
+                    </a>
+                </div>
+            </div>
+
+            <div class="relative flex flex-1 justify-end">
+                <div id="project-info-box" class="absolute bottom-6 right-0 w-64 rounded-2xl bg-black/85 px-6 py-5 shadow-2xl backdrop-blur">
+                    <p id="project-info-title" class="text-sm font-semibold uppercase tracking-[0.3em] text-white/60">
+                        <?php esc_html_e( 'Featured Project', 'boilerplate' ); ?>
+                    </p>
+                    <h3 id="project-info-subtitle" class="mt-3 text-xl font-semibold text-white">
+                        <?php esc_html_e( 'Boilerplate Studio', 'boilerplate' ); ?>
+                    </h3>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="pointer-events-none absolute inset-x-0 bottom-12 flex items-center justify-center gap-6">
+        <button id="hero-prev-slide" type="button" class="pointer-events-auto inline-flex h-12 w-12 items-center justify-center rounded-full border border-white/30 text-white transition hover:border-white hover:bg-white/10" aria-label="<?php esc_attr_e( 'Previous slide', 'boilerplate' ); ?>">
+            <svg class="h-5 w-5" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" viewBox="0 0 24 24">
+                <path d="M15 18l-6-6 6-6" />
+            </svg>
+        </button>
+        <div class="flex items-center justify-center gap-3">
+            <span class="hero-indicator h-2.5 w-2.5 rounded-full bg-white"></span>
+            <span class="hero-indicator h-2.5 w-2.5 rounded-full bg-white/40"></span>
+            <span class="hero-indicator h-2.5 w-2.5 rounded-full bg-white/40"></span>
+        </div>
+        <button id="hero-next-slide" type="button" class="pointer-events-auto inline-flex h-12 w-12 items-center justify-center rounded-full border border-white/30 text-white transition hover:border-white hover:bg-white/10" aria-label="<?php esc_attr_e( 'Next slide', 'boilerplate' ); ?>">
+            <svg class="h-5 w-5" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" viewBox="0 0 24 24">
+                <path d="M9 6l6 6-6 6" />
+            </svg>
+        </button>
+    </div>
+</section>

--- a/template-parts/navigation-mobile.php
+++ b/template-parts/navigation-mobile.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Off-canvas mobile navigation.
+ *
+ * @package WordPress_Boilerplate_2025
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+$menu_args = array(
+    'theme_location' => 'primary',
+    'menu_id'        => 'mobile-primary-menu',
+    'menu_class'     => 'flex flex-col gap-6 text-lg font-medium text-slate-900',
+    'container'      => '',
+    'echo'           => false,
+    'depth'          => 1,
+);
+
+if ( has_nav_menu( 'primary' ) ) {
+    $menu_markup = wp_nav_menu( $menu_args );
+} else {
+    $menu_markup = bp_fallback_menu(
+        array_merge(
+            $menu_args,
+            array(
+                'echo' => false,
+            )
+        )
+    );
+}
+
+if ( ! empty( $menu_markup ) ) {
+    $menu_markup = preg_replace_callback(
+        '/<li([^>]*)class="([^"]*)"/i',
+        static function( $matches ) {
+            $classes = $matches[2];
+            if ( false === strpos( $classes, 'mobile-stagger' ) ) {
+                $classes .= ' mobile-stagger';
+            }
+
+            return '<li' . $matches[1] . 'class="' . $classes . '"';
+        },
+        $menu_markup
+    );
+
+    $menu_markup = preg_replace(
+        '/<li(?![^>]*class=")/i',
+        '<li class="mobile-stagger"',
+        $menu_markup
+    );
+}
+?>
+<div id="mobile-backdrop" class="fixed inset-0 z-40 bg-slate-900/60 opacity-0 pointer-events-none transition-opacity duration-300 lg:hidden" hidden></div>
+
+<aside id="mobile-nav" class="fixed inset-y-0 right-0 z-50 flex w-full max-w-xs translate-x-full flex-col gap-6 bg-white px-6 pb-8 pt-6 shadow-xl opacity-0 pointer-events-none transition-all duration-300 lg:hidden" aria-hidden="true">
+    <div class="flex flex-col gap-1">
+        <span class="text-sm font-semibold uppercase tracking-wide text-slate-500"><?php bloginfo( 'name' ); ?></span>
+        <?php $tagline = get_bloginfo( 'description' ); ?>
+        <?php if ( ! empty( $tagline ) ) : ?>
+            <span class="text-xs text-slate-400"><?php echo esc_html( $tagline ); ?></span>
+        <?php endif; ?>
+    </div>
+
+    <nav aria-label="<?php esc_attr_e( 'Mobile Primary Menu', 'boilerplate' ); ?>" class="flex-1 overflow-y-auto">
+        <?php echo ! empty( $menu_markup ) ? wp_kses_post( $menu_markup ) : ''; ?>
+    </nav>
+
+    <div class="mt-auto flex flex-col gap-4">
+        <a class="inline-flex items-center justify-center rounded-full bg-slate-900 px-5 py-3 text-base font-semibold text-white transition hover:bg-slate-700" href="<?php echo esc_url( home_url( '/contact' ) ); ?>">
+            <?php esc_html_e( 'Start a Project', 'boilerplate' ); ?>
+        </a>
+        <p class="text-xs text-slate-500">
+            <?php esc_html_e( 'Update this call-to-action per project or replace it with something else.', 'boilerplate' ); ?>
+        </p>
+    </div>
+</aside>

--- a/wp-content/plugins/site-functionality/site-functionality.php
+++ b/wp-content/plugins/site-functionality/site-functionality.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Plugin Name: Site Functionality
+ * Plugin URI: https://example.com/
+ * Description: Scaffold for project-specific functionality (CPTs, taxonomies, ACF) that should live outside the theme.
+ * Version: 0.1.0
+ * Author: Your Name
+ * Author URI: https://example.com/
+ * License: GPL-2.0-or-later
+ * Text Domain: site-functionality
+ *
+ * Use this plugin as the home for any functionality you would otherwise add to a mu-plugin or the theme's functions.php.
+ * Duplicate it per project, rename the plugin header, and commit bespoke content types, taxonomies, or field groups here.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/*
+add_action( 'init', function() {
+    $labels = array(
+        'name'               => __( 'Projects', 'site-functionality' ),
+        'singular_name'      => __( 'Project', 'site-functionality' ),
+        'add_new'            => __( 'Add New', 'site-functionality' ),
+        'add_new_item'       => __( 'Add New Project', 'site-functionality' ),
+        'edit_item'          => __( 'Edit Project', 'site-functionality' ),
+        'new_item'           => __( 'New Project', 'site-functionality' ),
+        'view_item'          => __( 'View Project', 'site-functionality' ),
+        'search_items'       => __( 'Search Projects', 'site-functionality' ),
+        'not_found'          => __( 'No projects found', 'site-functionality' ),
+        'not_found_in_trash' => __( 'No projects found in Trash', 'site-functionality' ),
+        'all_items'          => __( 'All Projects', 'site-functionality' ),
+        'menu_name'          => __( 'Projects', 'site-functionality' ),
+    );
+
+    $args = array(
+        'labels'             => $labels,
+        'public'             => true,
+        'has_archive'        => true,
+        'rewrite'            => array( 'slug' => 'projects' ),
+        'menu_icon'          => 'dashicons-portfolio',
+        'supports'           => array( 'title', 'editor', 'thumbnail', 'excerpt' ),
+        'show_in_rest'       => true,
+    );
+
+    register_post_type( 'project', $args );
+});
+*/
+
+/*
+add_action( 'init', function() {
+    $labels = array(
+        'name'          => __( 'Project Categories', 'site-functionality' ),
+        'singular_name' => __( 'Project Category', 'site-functionality' ),
+        'search_items'  => __( 'Search Project Categories', 'site-functionality' ),
+        'all_items'     => __( 'All Project Categories', 'site-functionality' ),
+        'edit_item'     => __( 'Edit Project Category', 'site-functionality' ),
+        'update_item'   => __( 'Update Project Category', 'site-functionality' ),
+        'add_new_item'  => __( 'Add New Project Category', 'site-functionality' ),
+        'new_item_name' => __( 'New Project Category', 'site-functionality' ),
+        'menu_name'     => __( 'Project Categories', 'site-functionality' ),
+    );
+
+    register_taxonomy(
+        'project_category',
+        'project',
+        array(
+            'labels'       => $labels,
+            'hierarchical' => true,
+            'show_in_rest' => true,
+            'rewrite'      => array( 'slug' => 'project-category' ),
+        )
+    );
+});
+*/
+
+/*
+if ( function_exists( 'acf_add_local_field_group' ) ) {
+    add_action( 'acf/init', function() {
+        acf_add_local_field_group(
+            array(
+                'key'    => 'group_project_details',
+                'title'  => __( 'Project Details', 'site-functionality' ),
+                'fields' => array(
+                    array(
+                        'key'   => 'field_project_subtitle',
+                        'name'  => 'project_subtitle',
+                        'label' => __( 'Project Subtitle', 'site-functionality' ),
+                        'type'  => 'text',
+                    ),
+                ),
+                'location' => array(
+                    array(
+                        array(
+                            'param'    => 'post_type',
+                            'operator' => '==',
+                            'value'    => 'project',
+                        ),
+                    ),
+                ),
+            )
+        );
+    });
+}
+*/


### PR DESCRIPTION
## Summary
- add theme bootstrap helpers and optional module toggles in `functions.php` and `inc/`
- implement sticky header, mobile drawer navigation, and reusable hero module
- scaffold a Site Functionality plugin and document build/module usage in the README

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca9386f19883248b8e05a59062eb7f